### PR TITLE
Add CORS middleware to Go API

### DIFF
--- a/backend-api/main.go
+++ b/backend-api/main.go
@@ -1,29 +1,44 @@
 package main
 
 import (
-    "log"
-    "os"
+	"log"
+	"os"
 
-    "github.com/joho/godotenv"
-    "github.com/gin-gonic/gin"
-    "gorm.io/driver/mysql"
-    "gorm.io/gorm"
+	"github.com/gin-gonic/gin"
+	"github.com/joho/godotenv"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
 
-    "github.com/example/cms/backend/models"
-    "github.com/example/cms/backend/routes"
+	"github.com/example/cms/backend/models"
+	"github.com/example/cms/backend/routes"
 )
 
+func CORSMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type,Authorization")
+		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(204)
+			return
+		}
+		c.Next()
+	}
+}
+
 func main() {
-    godotenv.Load()
-    dsn := os.Getenv("DB_DSN")
-    db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
-    if err != nil {
-        log.Fatal(err)
-    }
-    db.AutoMigrate(&models.Post{})
+	godotenv.Load()
+	dsn := os.Getenv("DB_DSN")
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	db.AutoMigrate(&models.Post{})
 
-    r := gin.Default()
-    routes.RegisterRoutes(r, db)
+	r := gin.Default()
+	r.Use(CORSMiddleware())
+	routes.RegisterRoutes(r, db)
 
-    r.Run(":8080")
+	r.Run(":8080")
 }


### PR DESCRIPTION
## Summary
- add simple CORS middleware to backend API so requests from any origin are allowed

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e1ae26378832a94978f0eb77293b5