### PR TITLE
Handle chrome devtools request

### DIFF
--- a/backend-api/main.go
+++ b/backend-api/main.go
@@ -36,9 +36,16 @@ func main() {
 	}
 	db.AutoMigrate(&models.Post{})
 
-	r := gin.Default()
+	r := gin.New()
+	r.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+		SkipPaths: []string{"/.well-known/appspecific/com.chrome.devtools.json"},
+	}), gin.Recovery())
 	r.Use(CORSMiddleware())
 	routes.RegisterRoutes(r, db)
+
+	r.GET("/.well-known/appspecific/com.chrome.devtools.json", func(c *gin.Context) {
+		c.Status(200)
+	})
 
 	r.Run(":8080")
 }


### PR DESCRIPTION
## Summary
- register a route to handle Chrome's devtools `.well-known` request
- skip logging that request so Gin won't output 404

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e25108104832ab2e961de27331e92