### PR TITLE
Fix JSON field names

### DIFF
--- a/backend-api/models/post.go
+++ b/backend-api/models/post.go
@@ -3,7 +3,7 @@ package models
 import "gorm.io/gorm"
 
 type Post struct {
-    gorm.Model
-    Title   string `json:"title"`
-    Content string `json:"content"`
+	gorm.Model
+	Title   string
+	Content string
 }


### PR DESCRIPTION
## Summary
- keep Go default struct names for Post model

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e3128fad8832a89966a42e7f8f612